### PR TITLE
feat: add README and enhance highlight groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# 🌃 Cyberpunk.vim
+
+A dark Vim/Neovim colorscheme with neon green, cyan, yellow, and red highlights on a black background — inspired by the cyberpunk aesthetic.
+
+![Vim](https://img.shields.io/badge/Vim-8%2B-green?logo=vim)
+![Neovim](https://img.shields.io/badge/Neovim-0.5%2B-green?logo=neovim)
+
+## Palette
+
+| Role       | Color   | Hex       |
+|------------|---------|-----------|
+| Normal     | Green   | `#408000` |
+| Comment    | Cyan    | `#0eeafa` |
+| Constant   | Blue    | `#0197dd` |
+| Statement  | Yellow  | `#ffd302` |
+| Operator   | Red     | `#FF0000` |
+| Special    | Beige   | `#cdb1ad` |
+| Background | Black   | `#000000` |
+
+## Installation
+
+### vim-plug
+
+```vim
+Plug 'taigrr/cyberpunk.vim'
+```
+
+### lazy.nvim
+
+```lua
+{ "taigrr/cyberpunk.vim" }
+```
+
+### Packer
+
+```lua
+use 'taigrr/cyberpunk.vim'
+```
+
+### Manual
+
+Copy `colors/cyberpunk.vim` to `~/.vim/colors/` (Vim) or `~/.config/nvim/colors/` (Neovim).
+
+## Usage
+
+```vim
+colorscheme cyberpunk
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/colors/cyberpunk.vim
+++ b/colors/cyberpunk.vim
@@ -27,6 +27,55 @@ hi Todo			term=standout	ctermbg=75	ctermfg=226				guifg=#0197dd guibg=#ffd302
 
 hi Pmenu           ctermfg=black guifg=black ctermbg=70 guibg='#408000'
 hi PmenuSel        ctermfg=14 guifg='#0197DD' ctermbg=226 guibg='#FFD302'
+
+" UI elements
+hi LineNr		term=NONE					ctermfg=238				guifg=#444444
+hi CursorLineNr	term=bold					ctermfg=226	gui=bold	guifg=#ffd302
+hi CursorLine	term=NONE		cterm=NONE	ctermbg=234				guibg=#1a1a1a
+hi CursorColumn	term=NONE		cterm=NONE	ctermbg=234				guibg=#1a1a1a
+hi ColorColumn	term=NONE					ctermbg=234				guibg=#1a1a1a
+hi Visual		term=reverse				ctermbg=238				guibg=#333333
+hi VisualNOS	term=reverse				ctermbg=238				guibg=#333333
+hi Search		term=reverse	ctermfg=0	ctermbg=226				guifg=black	guibg=#ffd302
+hi IncSearch	term=reverse	ctermfg=0	ctermbg=14				guifg=black	guibg=#0eeafa
+hi MatchParen	term=reverse	ctermfg=226	ctermbg=238				guifg=#ffd302	guibg=#333333
+hi StatusLine	term=bold					ctermfg=70	ctermbg=234	guifg=#408000	guibg=#1a1a1a
+hi StatusLineNC	term=NONE					ctermfg=238	ctermbg=234	guifg=#444444	guibg=#1a1a1a
+hi VertSplit	term=NONE					ctermfg=238				guifg=#444444
+hi Folded		term=NONE					ctermfg=14	ctermbg=234	guifg=#0eeafa	guibg=#1a1a1a
+hi FoldColumn	term=NONE					ctermfg=14	ctermbg=234	guifg=#0eeafa	guibg=#1a1a1a
+hi SignColumn	term=NONE					ctermbg=NONE			guibg=NONE
+hi NonText		term=NONE					ctermfg=238				guifg=#444444
+hi SpecialKey	term=NONE					ctermfg=238				guifg=#444444
+hi Title		term=bold					ctermfg=226	gui=bold	guifg=#ffd302
+hi Directory	term=bold					ctermfg=14				guifg=#0eeafa
+hi WildMenu		term=standout	ctermfg=0	ctermbg=226				guifg=black	guibg=#ffd302
+hi TabLine		term=NONE					ctermfg=238	ctermbg=234	guifg=#444444	guibg=#1a1a1a
+hi TabLineSel	term=bold					ctermfg=70	ctermbg=0	guifg=#408000	guibg=black
+hi TabLineFill	term=NONE					ctermbg=234				guibg=#1a1a1a
+
+" Diff
+hi DiffAdd		term=bold					ctermbg=22				guibg=#003300
+hi DiffChange	term=bold					ctermbg=17				guibg=#000033
+hi DiffDelete	term=bold		ctermfg=9	ctermbg=52				guifg=#FF0000	guibg=#330000
+hi DiffText		term=reverse				ctermbg=57	gui=bold	guibg=#0C35BF
+
+" Diagnostics (Neovim LSP)
+hi DiagnosticError						ctermfg=9				guifg=#FF0000
+hi DiagnosticWarn						ctermfg=226				guifg=#ffd302
+hi DiagnosticInfo						ctermfg=75				guifg=#0197dd
+hi DiagnosticHint						ctermfg=14				guifg=#0eeafa
+hi DiagnosticUnderlineError	term=underline	cterm=underline	gui=undercurl	guisp=#FF0000
+hi DiagnosticUnderlineWarn	term=underline	cterm=underline	gui=undercurl	guisp=#ffd302
+hi DiagnosticUnderlineInfo	term=underline	cterm=underline	gui=undercurl	guisp=#0197dd
+hi DiagnosticUnderlineHint	term=underline	cterm=underline	gui=undercurl	guisp=#0eeafa
+
+" Spell
+hi SpellBad		term=underline	cterm=underline	gui=undercurl	guisp=#FF0000
+hi SpellCap		term=underline	cterm=underline	gui=undercurl	guisp=#0197dd
+hi SpellRare	term=underline	cterm=underline	gui=undercurl	guisp=#cdb1ad
+hi SpellLocal	term=underline	cterm=underline	gui=undercurl	guisp=#0eeafa
+
 " Common groups that link to default highlighting.
 " You can specify other highlighting easily.
 hi link String	Constant


### PR DESCRIPTION
## Changes
- Add README.md with installation instructions, palette reference, and plugin manager examples
- Add UI element highlights: line numbers, cursor line, status line, vertical splits, tabs, folds
- Add search, visual mode, and match paren highlights
- Add diff highlights for version control integration
- Add Neovim LSP diagnostic highlights (Error, Warn, Info, Hint + underlines)
- Add spell checking highlights

## Context
The colorscheme only had basic syntax highlights. This adds comprehensive UI and editor highlights to make the theme feel complete across Vim and Neovim.